### PR TITLE
Sign out on failure to refresh tokens

### DIFF
--- a/app/src/main/java/dev/sanson/lightroom/MuzeiLightroomApplication.kt
+++ b/app/src/main/java/dev/sanson/lightroom/MuzeiLightroomApplication.kt
@@ -6,6 +6,7 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import dev.sanson.lightroom.sdk.Lightroom
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -17,4 +18,10 @@ class MuzeiLightroomApplication : Application(), Configuration.Provider {
         Configuration.Builder()
             .setWorkerFactory(workerFactory)
             .build()
+
+    override fun onCreate() {
+        super.onCreate()
+
+        Lightroom.installTokenRefresher(context = applicationContext)
+    }
 }

--- a/app/src/main/java/dev/sanson/lightroom/MuzeiLightroomApplication.kt
+++ b/app/src/main/java/dev/sanson/lightroom/MuzeiLightroomApplication.kt
@@ -13,7 +13,7 @@ class MuzeiLightroomApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
-    override val workManagerConfiguration: Configuration =
+    override val workManagerConfiguration: Configuration get() =
         Configuration.Builder()
             .setWorkerFactory(workerFactory)
             .build()

--- a/lib/lightroom/build.gradle.kts
+++ b/lib/lightroom/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 dependencies {
     implementation(libs.androidx.browser)
     implementation(libs.androidx.datastore)
+    implementation(libs.androidx.work)
 
     implementation(libs.retrofit)
     implementation(libs.retrofit.kotlinx.serialization.converter)

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
@@ -13,6 +13,7 @@ import dev.sanson.lightroom.sdk.domain.GetAccountUseCase
 import dev.sanson.lightroom.sdk.domain.GetAlbumAssetsUseCase
 import dev.sanson.lightroom.sdk.domain.GetAlbumsUseCase
 import dev.sanson.lightroom.sdk.domain.GetCatalogAssetsUseCase
+import dev.sanson.lightroom.sdk.domain.IsSignedInUseCase
 import dev.sanson.lightroom.sdk.model.Account
 import dev.sanson.lightroom.sdk.model.AlbumId
 import dev.sanson.lightroom.sdk.model.AlbumTreeItem
@@ -120,6 +121,7 @@ suspend fun Lightroom.getImageAuthHeaders(): Map<String, String> {
 }
 
 internal class DefaultLightroom(
+    getIsSignedIn: IsSignedInUseCase,
     internal val authManager: AuthManager,
     internal val clientId: String,
     private val retrieveAlbums: GetAlbumsUseCase,
@@ -129,7 +131,7 @@ internal class DefaultLightroom(
     private val retrieveAccount: GetAccountUseCase,
     private val catalogRepository: CatalogRepository,
 ) : Lightroom {
-    override val isSignedIn = authManager.isSignedIn
+    override val isSignedIn = getIsSignedIn()
 
     override fun signIn(context: Context) {
         val intent = CustomTabsIntent.Builder().build()

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
@@ -87,7 +87,6 @@ interface Lightroom {
     suspend fun getAccount(): Account
 
     companion object {
-
         /**
          * Install a WorkManager worker to periodically update our tokens, ensuring we
          * don't need to ask the user to sign in again
@@ -164,8 +163,7 @@ internal class DefaultLightroom(
 
     override suspend fun getCatalogAssets(): List<Asset> = retrieveCatalogAssets()
 
-    override suspend fun getAlbumAssets(albumId: AlbumId): List<Asset> =
-        retrieveAlbumAssets(albumId = albumId)
+    override suspend fun getAlbumAssets(albumId: AlbumId): List<Asset> = retrieveAlbumAssets(albumId = albumId)
 
     override suspend fun generateRendition(
         asset: AssetId,

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
@@ -9,9 +9,11 @@ import dev.sanson.lightroom.sdk.backend.auth.AuthManager
 import dev.sanson.lightroom.sdk.di.DaggerLightroomComponent
 import dev.sanson.lightroom.sdk.domain.CatalogRepository
 import dev.sanson.lightroom.sdk.domain.GenerateRenditionUseCase
+import dev.sanson.lightroom.sdk.domain.GetAccountUseCase
 import dev.sanson.lightroom.sdk.domain.GetAlbumAssetsUseCase
 import dev.sanson.lightroom.sdk.domain.GetAlbumsUseCase
 import dev.sanson.lightroom.sdk.domain.GetCatalogAssetsUseCase
+import dev.sanson.lightroom.sdk.model.Account
 import dev.sanson.lightroom.sdk.model.AlbumId
 import dev.sanson.lightroom.sdk.model.AlbumTreeItem
 import dev.sanson.lightroom.sdk.model.Asset
@@ -74,6 +76,13 @@ interface Lightroom {
         asset: AssetId,
         rendition: Rendition,
     )
+
+    /**
+     * Retrieve the user account metadata
+     *
+     * https://developer.adobe.com/lightroom/lightroom-api-docs/api/#tag/Accounts/operation/getAccount
+     */
+    suspend fun getAccount(): Account
 }
 
 /**
@@ -117,6 +126,7 @@ internal class DefaultLightroom(
     private val retrieveAlbumAssets: GetAlbumAssetsUseCase,
     private val retrieveCatalogAssets: GetCatalogAssetsUseCase,
     private val generateRenditions: GenerateRenditionUseCase,
+    private val retrieveAccount: GetAccountUseCase,
     private val catalogRepository: CatalogRepository,
 ) : Lightroom {
     override val isSignedIn = authManager.isSignedIn
@@ -144,4 +154,6 @@ internal class DefaultLightroom(
         asset: AssetId,
         rendition: Rendition,
     ) = generateRenditions(asset, rendition)
+
+    override suspend fun getAccount(): Account = retrieveAccount()
 }

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/Lightroom.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.browser.customtabs.CustomTabsIntent
 import dev.sanson.lightroom.sdk.backend.auth.AuthManager
+import dev.sanson.lightroom.sdk.backend.auth.TokenRefreshWorker
 import dev.sanson.lightroom.sdk.di.DaggerLightroomComponent
 import dev.sanson.lightroom.sdk.domain.CatalogRepository
 import dev.sanson.lightroom.sdk.domain.GenerateRenditionUseCase
@@ -84,6 +85,19 @@ interface Lightroom {
      * https://developer.adobe.com/lightroom/lightroom-api-docs/api/#tag/Accounts/operation/getAccount
      */
     suspend fun getAccount(): Account
+
+    companion object {
+
+        /**
+         * Install a WorkManager worker to periodically update our tokens, ensuring we
+         * don't need to ask the user to sign in again
+         *
+         * @param context Application context
+         */
+        fun installTokenRefresher(context: Context) {
+            TokenRefreshWorker.enqueue(context)
+        }
+    }
 }
 
 /**
@@ -150,7 +164,8 @@ internal class DefaultLightroom(
 
     override suspend fun getCatalogAssets(): List<Asset> = retrieveCatalogAssets()
 
-    override suspend fun getAlbumAssets(albumId: AlbumId): List<Asset> = retrieveAlbumAssets(albumId = albumId)
+    override suspend fun getAlbumAssets(albumId: AlbumId): List<Asset> =
+        retrieveAlbumAssets(albumId = albumId)
 
     override suspend fun generateRendition(
         asset: AssetId,

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/LightroomModule.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/LightroomModule.kt
@@ -19,9 +19,11 @@ import dev.sanson.lightroom.sdk.backend.interceptor.RemoveBodyPrefixInterceptor
 import dev.sanson.lightroom.sdk.backend.serializer.LenientInstantSerializer
 import dev.sanson.lightroom.sdk.domain.CatalogRepository
 import dev.sanson.lightroom.sdk.domain.GenerateRenditionUseCase
+import dev.sanson.lightroom.sdk.domain.GetAccountUseCase
 import dev.sanson.lightroom.sdk.domain.GetAlbumAssetsUseCase
 import dev.sanson.lightroom.sdk.domain.GetAlbumsUseCase
 import dev.sanson.lightroom.sdk.domain.GetCatalogAssetsUseCase
+import dev.sanson.lightroom.sdk.domain.IsSignedInUseCase
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
@@ -135,9 +137,12 @@ internal class LightroomModule {
         retrieveAlbumAssets: GetAlbumAssetsUseCase,
         retrieveCatalogAssets: GetCatalogAssetsUseCase,
         generateRendition: GenerateRenditionUseCase,
+        getAccount: GetAccountUseCase,
+        isSignedIn: IsSignedInUseCase,
         catalogRepository: CatalogRepository,
     ): Lightroom {
         return DefaultLightroom(
+            getIsSignedIn = isSignedIn,
             authManager = authManager,
             clientId = clientId,
             retrieveAlbums = retrieveAlbums,
@@ -145,6 +150,7 @@ internal class LightroomModule {
             retrieveCatalogAssets = retrieveCatalogAssets,
             catalogRepository = catalogRepository,
             generateRenditions = generateRendition,
+            retrieveAccount = getAccount,
         )
     }
 }

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/auth/AuthManager.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/auth/AuthManager.kt
@@ -35,7 +35,7 @@ internal class AuthManager
     ) {
         private var previousChallenge: String? = null
 
-        val isSignedIn = credentialStore.credential.map { it != null }
+        val hasCredentials = credentialStore.credential.map { it != null }
 
         val latestAccessToken = credentialStore.credential.map { it?.accessToken }
 

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/auth/TokenRefreshWorker.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/auth/TokenRefreshWorker.kt
@@ -1,0 +1,69 @@
+package dev.sanson.lightroom.sdk.backend.auth
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dev.sanson.lightroom.sdk.DefaultLightroom
+import dev.sanson.lightroom.sdk.Lightroom
+import kotlinx.coroutines.coroutineScope
+import retrofit2.HttpException
+import java.util.concurrent.TimeUnit
+
+internal class TokenRefreshWorker(
+    context: Context,
+    params: WorkerParameters
+): CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result = coroutineScope {
+        val lightroom = Lightroom(context = applicationContext, coroutineScope = this)
+        lightroom as DefaultLightroom
+
+        runCatching {
+            lightroom.authManager.refreshTokens()
+        }.fold(
+            onSuccess = { Result.success() },
+            onFailure = { error ->
+                when (error) {
+                    is HttpException -> Result.failure()
+                    else -> Result.retry()
+                }
+            }
+        )
+    }
+
+    companion object {
+        private const val TOKEN_REFRESH_WORK_NAME = "lightroom_token_refresh"
+
+        fun enqueue(context: Context) {
+            val refreshConstraints = Constraints(
+                requiredNetworkType = NetworkType.CONNECTED,
+                requiresBatteryNotLow = true,
+            )
+
+            // Refresh tokens every week, near the end of said week
+            val requestBuilder = PeriodicWorkRequestBuilder<TokenRefreshWorker>(
+                repeatInterval = 7,
+                repeatIntervalTimeUnit = TimeUnit.DAYS,
+                flexTimeInterval = 1,
+                flexTimeIntervalUnit = TimeUnit.DAYS,
+            )
+
+            val request = requestBuilder
+                .setConstraints(refreshConstraints)
+                .setInitialDelay(duration = 1, TimeUnit.DAYS)
+                .setBackoffCriteria(BackoffPolicy.LINEAR, backoffDelay = 1, TimeUnit.HOURS)
+                .build()
+
+            val workManager = WorkManager.getInstance(context)
+
+            workManager
+                .enqueueUniquePeriodicWork(TOKEN_REFRESH_WORK_NAME, ExistingPeriodicWorkPolicy.KEEP, request)
+        }
+    }
+}

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/auth/TokenRefreshWorker.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/auth/TokenRefreshWorker.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2023, Jamie Sanson
+// SPDX-License-Identifier: Apache-2.0
 package dev.sanson.lightroom.sdk.backend.auth
 
 import android.content.Context
@@ -17,48 +19,51 @@ import java.util.concurrent.TimeUnit
 
 internal class TokenRefreshWorker(
     context: Context,
-    params: WorkerParameters
-): CoroutineWorker(context, params) {
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+    override suspend fun doWork(): Result =
+        coroutineScope {
+            val lightroom = Lightroom(context = applicationContext, coroutineScope = this)
+            lightroom as DefaultLightroom
 
-    override suspend fun doWork(): Result = coroutineScope {
-        val lightroom = Lightroom(context = applicationContext, coroutineScope = this)
-        lightroom as DefaultLightroom
-
-        runCatching {
-            lightroom.authManager.refreshTokens()
-        }.fold(
-            onSuccess = { Result.success() },
-            onFailure = { error ->
-                when (error) {
-                    is HttpException -> Result.failure()
-                    else -> Result.retry()
-                }
-            }
-        )
-    }
+            runCatching {
+                lightroom.authManager.refreshTokens()
+            }.fold(
+                onSuccess = { Result.success() },
+                onFailure = { error ->
+                    when (error) {
+                        is HttpException -> Result.failure()
+                        else -> Result.retry()
+                    }
+                },
+            )
+        }
 
     companion object {
         private const val TOKEN_REFRESH_WORK_NAME = "lightroom_token_refresh"
 
         fun enqueue(context: Context) {
-            val refreshConstraints = Constraints(
-                requiredNetworkType = NetworkType.CONNECTED,
-                requiresBatteryNotLow = true,
-            )
+            val refreshConstraints =
+                Constraints(
+                    requiredNetworkType = NetworkType.CONNECTED,
+                    requiresBatteryNotLow = true,
+                )
 
             // Refresh tokens every week, near the end of said week
-            val requestBuilder = PeriodicWorkRequestBuilder<TokenRefreshWorker>(
-                repeatInterval = 7,
-                repeatIntervalTimeUnit = TimeUnit.DAYS,
-                flexTimeInterval = 1,
-                flexTimeIntervalUnit = TimeUnit.DAYS,
-            )
+            val requestBuilder =
+                PeriodicWorkRequestBuilder<TokenRefreshWorker>(
+                    repeatInterval = 7,
+                    repeatIntervalTimeUnit = TimeUnit.DAYS,
+                    flexTimeInterval = 1,
+                    flexTimeIntervalUnit = TimeUnit.DAYS,
+                )
 
-            val request = requestBuilder
-                .setConstraints(refreshConstraints)
-                .setInitialDelay(duration = 1, TimeUnit.DAYS)
-                .setBackoffCriteria(BackoffPolicy.LINEAR, backoffDelay = 1, TimeUnit.HOURS)
-                .build()
+            val request =
+                requestBuilder
+                    .setConstraints(refreshConstraints)
+                    .setInitialDelay(duration = 1, TimeUnit.DAYS)
+                    .setBackoffCriteria(BackoffPolicy.LINEAR, backoffDelay = 1, TimeUnit.HOURS)
+                    .build()
 
             val workManager = WorkManager.getInstance(context)
 

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/interceptor/LightroomAuthenticator.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/backend/interceptor/LightroomAuthenticator.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.sanson.lightroom.sdk.backend.interceptor
 
+import android.util.Log
 import dev.sanson.lightroom.sdk.backend.auth.AuthManager
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
@@ -18,7 +19,17 @@ internal class LightroomAuthenticator(
     ): Request? {
         // If we get a 401 and we've used an auth header in the previous request, try refresh tokens
         return if (response.code == 401 && response.request.headers["Authorization"] != null) {
-            val credentials = runBlocking { authManager.refreshTokens() }
+            val credentials =
+                runBlocking {
+                    try {
+                        authManager.refreshTokens()
+                    } catch (e: Exception) {
+                        Log.w("LightroomAuthenticator", "Token refresh failed", e)
+                        null
+                    }
+                }
+
+            credentials ?: return null
 
             response.request.newBuilder()
                 .removeHeader("Authorization")

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/domain/GetAccountUseCase.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/domain/GetAccountUseCase.kt
@@ -1,0 +1,15 @@
+// Copyright (C) 2023, Jamie Sanson
+// SPDX-License-Identifier: Apache-2.0
+package dev.sanson.lightroom.sdk.domain
+
+import dev.sanson.lightroom.sdk.backend.AccountService
+import dev.sanson.lightroom.sdk.model.Account
+import javax.inject.Inject
+
+internal class GetAccountUseCase @Inject constructor(
+    private val accountService: AccountService,
+) {
+    suspend operator fun invoke(): Account {
+        return Account(accountService.getAccount().firstName)
+    }
+}

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/domain/IsSignedInUseCase.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/domain/IsSignedInUseCase.kt
@@ -1,0 +1,30 @@
+// Copyright (C) 2023, Jamie Sanson
+// SPDX-License-Identifier: Apache-2.0
+package dev.sanson.lightroom.sdk.domain
+
+import dev.sanson.lightroom.sdk.backend.auth.AuthManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
+import retrofit2.HttpException
+import javax.inject.Inject
+
+internal class IsSignedInUseCase @Inject constructor(
+    private val scope: CoroutineScope,
+    private val authManager: AuthManager,
+    private val retrieveAccount: GetAccountUseCase,
+) {
+    operator fun invoke(): SharedFlow<Boolean> {
+        return authManager.hasCredentials
+            .map { hasCredential ->
+                hasCredential &&
+                    runCatching { retrieveAccount() }.fold(
+                        onSuccess = { true },
+                        onFailure = { error -> error !is HttpException },
+                    )
+            }
+            .shareIn(scope, SharingStarted.Eagerly)
+    }
+}

--- a/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/model/Account.kt
+++ b/lib/lightroom/src/main/kotlin/dev/sanson/lightroom/sdk/model/Account.kt
@@ -1,0 +1,7 @@
+// Copyright (C) 2023, Jamie Sanson
+// SPDX-License-Identifier: Apache-2.0
+package dev.sanson.lightroom.sdk.model
+
+data class Account(
+    val firstName: String,
+)


### PR DESCRIPTION
Refresh tokens for the Adobe APIs have a 14 day lifetime, and the current state of the app would simply crash if you haven't launched it in two weeks. Instead, ask the user to sign in again on app start. 

This had a flow-on effect of meaning we stop being able to load images from your library every two weeks. Not ideal. To address this, I've added in a periodic bit of work which refreshes tokens in the background.